### PR TITLE
Update mtu130_flop.xml

### DIFF
--- a/hash/mtu130_flop.xml
+++ b/hash/mtu130_flop.xml
@@ -73,6 +73,83 @@ Floppies for the MTU-130.
 		</part>
 	</software>
 
+	<software name="macasm">
+		<description>Macro Assembler</description>
+		<year>1982</year>
+		<publisher>Micro Technology Unlimited</publisher>
+		<part name="flop1" interface="floppy_8">
+			<dataarea name="flop" size="514935">
+				<rom name="Distribution_Disk_1.4_1982_-_MACASM.imd" size="514965" crc="beacf09f" sha1="9f0fdf38db22beea609f440a4381638d48877c12"/>
+			</dataarea>
+		</part>
+	</software>
+
+ <software name="wordpic10nec">
+		<description>Wordpic 1.0 NEC 8023 Version</description>
+		<year>1983</year>
+		<publisher>Micro Technology Unlimited</publisher>
+		<part name="flop1" interface="floppy_8">
+			<dataarea name="flop" size="702886">
+				<rom name="Distribution_Disk_1983_-_Wordpic_1.0_NEC_8023_Printer_Version.imd" size="702886" crc="4a7b3108" sha1="6f588e268a11c6a7a218f68c8c2a7c30be44a994"/>
+			</dataarea>
+		</part>
+ </software>
+
+ <software name="mtuforth79">
+		<description>MTU-Forth79</description>
+		<year>1984</year>
+		<publisher>Micro Technology Unlimited</publisher>
+		<part name="flop1" interface="floppy_8">
+			<dataarea name="flop" size="237738">
+				<rom name="Option_Software_Disk_1.6_1984_-_MTU-Forth79_2.1.imd" size="237738" crc="a7608f99" sha1="f3378bb6fa7e94c4007c836100347ecb958e9d9e"/>
+			</dataarea>
+		</part>
+ </software>
+
+ <software name="dmxmon">
+		<description>Datamover Monitor</description>
+		<year>1982</year>
+		<publisher>Micro Technology Unlimited</publisher>
+		<part name="flop1" interface="floppy_8">
+			<dataarea name="flop" size="195675">
+				<rom name="Optional_Software_Disk_1.0_1982_-_DMXMON.imd" size="195675" crc="c65ec977" sha1="e3e3bf9f5d0b48bda52250c74c5a0615aa86a8bc"/>
+			</dataarea>
+		</part>
+ </software>
+
+ <software name="wordpic10">
+		<description>Wordpic 1.0</description>
+		<year>1982</year>
+		<publisher>Micro Technology Unlimited</publisher>
+		<part name="flop1" interface="floppy_8">
+			<dataarea name="flop" size="349695">
+				<rom name="Optional_Software_Disk_1.0_1982_-_Wordpic.imd" size="349695" crc="80b35019" sha1="e691204b7a850e2b60de734e52a9118e7ab39911"/>
+			</dataarea>
+		</part>
+ </software>
+
+ <software name="mtuc">
+		<description>MTU-C Compiler</description>
+		<year>1982</year>
+		<publisher>Micro Technology Unlimited</publisher>
+		<part name="flop1" interface="floppy_8">
+			<dataarea name="flop" size="319860">
+				<rom name="Optional_Software_Disk_1.2_1982_-_MTU-C.imd" size="319860" crc="29a1c1bc" sha1="ca8ae58618cfe46eb7eb885c522eef63896f46b3"/>
+			</dataarea>
+		</part>
+ </software>
+
+ <software name="magicl">
+		<description>MAGIC/L Language</description>
+		<year>?</year>
+		<publisher>Micro Technology Unlimited</publisher>
+		<part name="flop1" interface="floppy_8">
+			<dataarea name="flop" size="287985">
+				<rom name="Optional_Software_Disk_1.6_-_MAGIC-L_Language.imd" size="287985" crc="12cabe65" sha1="b7fb0bdadcb4151b00b56b3cb789303a501ea0d2"/>
+			</dataarea>
+		</part>
+ </software>
+
 </softwarelist>
 
 


### PR DESCRIPTION
Added software entries for MACASM, Wordpic 1.0, Wordpic 1.0 NEC 8023 printer version, MTU-Forth79, Datamover Monitor, MTU-C, MAGIC/L.